### PR TITLE
Fixes Bug: TokenForm fetchItems

### DIFF
--- a/src/TokenForm.js
+++ b/src/TokenForm.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useHistory } from 'react-router';
 import { collection, query, onSnapshot } from '@firebase/firestore';
 import { db } from './lib/firebase.js';
@@ -11,24 +11,23 @@ const TokenForm = () => {
   const [formError, setFormError] = useState(false);
   const [tokens, setTokens] = useState('');
 
+  const unsubscribeRef = useRef();
+
   useEffect(() => {
     const fetchItems = async () => {
       const response = collection(db, 'shopping-list');
       const itemList = query(response);
-
-      const unsubscribe = onSnapshot(itemList, (querySnapshot) => {
+      unsubscribeRef.current = onSnapshot(itemList, (querySnapshot) => {
         const tokens = querySnapshot.docs.reduce((acc, doc) => {
           const { userToken } = doc.data();
           return [...acc, userToken];
         }, []);
-
         console.log('tokens: ', tokens);
         setTokens(tokens);
       });
-      return unsubscribe;
     };
     fetchItems();
-    return fetchItems;
+    return unsubscribeRef.current;
   }, []);
 
   const handleChange = (e) => {

--- a/src/TokenForm.js
+++ b/src/TokenForm.js
@@ -27,7 +27,7 @@ const TokenForm = () => {
       });
       return unsubscribe;
     };
-
+    fetchItems();
     return fetchItems;
   }, []);
 


### PR DESCRIPTION

FetchItems wasn't being called after previous PR.  fetchItems is added back so that the form validation logic works.

## Related Issue

closes #25 

## Acceptance Criteria

- [ ] as a user, when I add a token which already exists in the database then I will see an error.

## Type of Changes



|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
|   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |



### Before

=> existing token produces error on click
![image](https://user-images.githubusercontent.com/26528573/139600748-9a31a9be-b466-4675-814a-538b1dd36f10.png)


### After

=> existing token does not produce error on click


