### PR TITLE
As an item, I want my estimated next purchase date to be computed at the time my purchase is recorded in the database so the app can learn how often I buy different items.

### DIFF
--- a/src/AddForm.js
+++ b/src/AddForm.js
@@ -62,6 +62,8 @@ function AddForm() {
       name: item,
       days,
       lastPurchasedDate: null,
+      estimatedPurchaseDate: null,
+      totalPurchases: 0,
       userToken,
     });
   }

--- a/src/AddForm.js
+++ b/src/AddForm.js
@@ -62,7 +62,7 @@ function AddForm() {
       name: item,
       days,
       lastPurchasedDate: null,
-      estimatedPurchaseDate: null,
+      previousEstimate: null,
       totalPurchases: 0,
       userToken,
     });

--- a/src/List.js
+++ b/src/List.js
@@ -40,8 +40,9 @@ export function List() {
           name,
           userToken,
           lastPurchasedDate,
-          estimatedPurchaseDate,
+          previousEstimate,
           totalPurchases,
+          days,
         } = doc.data();
         const id = doc.id;
         return {
@@ -49,8 +50,9 @@ export function List() {
           name,
           userToken,
           lastPurchasedDate,
-          estimatedPurchaseDate,
+          previousEstimate,
           totalPurchases,
+          days,
         };
       });
 
@@ -90,8 +92,8 @@ export function List() {
         itemRef,
         {
           lastPurchasedDate: date.getTime(),
-          estimatedPurchaseDate: calculateEstimate(
-            item.estimatedPurchaseDate,
+          previousEstimate: calculateEstimate(
+            item.previousEstimate || parseInt(item.days),
             daysSinceLastTransaction,
             item.totalPurchases,
           ),

--- a/src/List.js
+++ b/src/List.js
@@ -101,13 +101,6 @@ export function List() {
         },
         { merge: true },
       );
-    } else {
-      const itemRef = doc(db, 'shopping-list', id);
-      setDoc(
-        itemRef,
-        { lastPurchasedDate: null, totalPurchases: item.totalPurchases - 1 },
-        { merge: true },
-      );
     }
   };
   if (items.length) {

--- a/src/List.js
+++ b/src/List.js
@@ -8,6 +8,7 @@ import {
   where,
 } from '@firebase/firestore';
 import { db } from './lib/firebase.js';
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 import { Link } from 'react-router-dom';
 import { NavigationMenu } from './NavigationMenu';
 import { useHistory } from 'react-router-dom';
@@ -24,7 +25,6 @@ export function List() {
     const token = localStorage.getItem('token');
 
     const fetchItems = async () => {
-
       const token = localStorage.getItem('token');
       if (!token) {
         history.push('/');
@@ -74,43 +74,53 @@ export function List() {
     const checked = event.target.checked;
     if (checked) {
       const itemRef = doc(db, 'shopping-list', id);
-      setDoc(itemRef, { lastPurchasedDate: date.getTime() }, { merge: true });
+      setDoc(
+        itemRef,
+        {
+          lastPurchasedDate: date.getTime(),
+          //pull the data from the database before running calculateEstimate
+          estimatedPurchaseDate: calculateEstimate(),
+          //increment by one
+          // totalPurchases: totalPurchases++
+        },
+        { merge: true },
+      );
     } else {
       const itemRef = doc(db, 'shopping-list', id);
       setDoc(itemRef, { lastPurchasedDate: null }, { merge: true });
     }
   };
-if (items.length) {
-  return (
-    <div>
-      <ul className="list">
-        {items &&
-          items
-            .filter((item) => !!item.id)
-            .map((item) => {
-              return (
-                <li key={item.id}>
-                  <input
-                    type="checkbox"
-                    id={`custon-checkbox-${item.id}`}
-                    name={item.name}
-                    value={item.name}
-                    checked={
-                      !!item.lastPurchasedDate &&
-                      new Date() - item.lastPurchasedDate < ONE_MINUTE
-                    }
-                    onChange={(e) => handleChange(item.id, e)}
-                  />
-                  <label htmlFor={`custom-checkbox-${item.id}`}>
-                    {item.name}
-                  </label>
-                </li>
-              );
-            })}
-      </ul>
-      <NavigationMenu />
-    </div>
-  );
+  if (items.length) {
+    return (
+      <div>
+        <ul className="list">
+          {items &&
+            items
+              .filter((item) => !!item.id)
+              .map((item) => {
+                return (
+                  <li key={item.id}>
+                    <input
+                      type="checkbox"
+                      id={`custon-checkbox-${item.id}`}
+                      name={item.name}
+                      value={item.name}
+                      checked={
+                        !!item.lastPurchasedDate &&
+                        new Date() - item.lastPurchasedDate < ONE_MINUTE
+                      }
+                      onChange={(e) => handleChange(item.id, e)}
+                    />
+                    <label htmlFor={`custom-checkbox-${item.id}`}>
+                      {item.name}
+                    </label>
+                  </li>
+                );
+              })}
+        </ul>
+        <NavigationMenu />
+      </div>
+    );
   } else {
     return (
       <>


### PR DESCRIPTION
## Description

We added functionality that calculates an estimate of the number of days for the next purchase using the calculateEstimate utility and records it to the firestore. 

## Related Issue

closes #10 

## Acceptance Criteria

- [ ] When a purchase is recorded, the estimated number of days until the next purchase date should be calculated and recorded in the database

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates


### After


![image](https://user-images.githubusercontent.com/26528573/139895001-10cc1823-8978-4a57-9424-ba63c5444885.png)

