### PR TITLE
updated no items view

### DIFF
--- a/src/List.js
+++ b/src/List.js
@@ -25,6 +25,7 @@ import {
   ListItemIcon,
   ListItemText,
   TextField,
+  Button,
 } from '@mui/material';
 import ClearIcon from '@mui/icons-material/Clear';
 
@@ -58,6 +59,7 @@ export function List() {
   const [reRender, setReRender] = useState();
   const history = useHistory();
   const [filterItem, setFilterItem] = useState('');
+  const [listIsShown, setListIsShown] = useState(false);
 
   //only change to 60*60*24  for 24 hours
   const ONE_DAY = 60 * 60 * 24 * 1000;
@@ -175,7 +177,7 @@ export function List() {
     }
   };
 
-  return items.length ? (
+  return listIsShown || items.length ? (
     <>
       <AddForm />
       <Box
@@ -191,7 +193,6 @@ export function List() {
         <Box
           sx={{
             margin: 'auto',
-
             display: 'flex',
             flexDirection: 'row',
             justifyContent: 'space-evenly',
@@ -260,13 +261,31 @@ export function List() {
     </>
   ) : (
     <>
-      <p>
-        Welcome, friend! Your list is currently empty. Click below to add a new
-        item!
-      </p>
-      <Link to={`/add`}>
-        <button>Add item</button>
-      </Link>
+      <Box
+        sx={{
+          width: 368,
+          display: 'flex',
+          margin: 'auto',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          '& > :not(style)': { m: 1 },
+        }}
+      >
+        <h3>
+          Welcome, friend! Your list is currently empty. Click below to add your
+          first item!
+        </h3>
+
+        <Button
+          variant="outlined"
+          type="submit"
+          id="submit-item"
+          onClick={() => setListIsShown(true)}
+        >
+          {' '}
+          Get Started
+        </Button>
+      </Box>
       {/* <NavigationMenu /> */}
     </>
   );


### PR DESCRIPTION

## Description

Updates add items view with material UI. Fixes bug where it goes to the Add page from the no items page.

## Related Issue

closes #50 

## Acceptance Criteria

AC:
- [ ] When user has no items in their list, they are greeted by a message prompting them to add something to the list which is consistent with the colour, look, feel, and typography of the rest of the app
- [ ] (Optional) an image of an orange or similar accompanying the message

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓ | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|  ✓ | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

![image](https://user-images.githubusercontent.com/26528573/143479629-b210ae75-9816-446b-bbe6-4acc1c2f78c1.png)


### After
![image](https://user-images.githubusercontent.com/26528573/143479551-d6d25a00-594b-4e5d-aa9c-b32e98aac115.png)


